### PR TITLE
Added logic to check if user is root and modify home directory location

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,34 +13,32 @@
     name=awscli
     state=latest
 
-- name: 'Create the AWS config directory'
-  tags: 'aws-cli'
-  sudo: 'yes'
-  file: >
-    path=/home/{{ aws_cli_user }}/.aws
-    state=directory
-    owner={{ aws_cli_user }}
-    group={{ aws_cli_user }}
-    mode=0755
+- name: Set home directory of the user
+  set_fact:
+    home_dir: /home/{{ aws_cli_user }}
   when: "not {{ aws_cli_user }} == \"root\""
+
+- name: Set home directory for root
+  set_fact:
+    home_dir: /root
+  when: "{{ aws_cli_user }} == \"root\""
 
 - name: 'Create the AWS config directory'
   tags: 'aws-cli'
   sudo: 'yes'
   file: >
-    path=/root/.aws
+    path={{ home_dir }}/.aws
     state=directory
-    owner=root
-    group=root
+    owner={{ aws_cli_user }}
+    group={{ aws_cli_user }}
     mode=0755
-  when: "{{ aws_cli_user }} == \"root\""
 
 - name: 'Copy AWS CLI config'
   tags: 'aws-cli'
   sudo: 'yes'
   template: >
     src=aws_cli_config.j2
-    dest=/home/{{ aws_cli_user }}/.aws/config
+    dest={{ home_dir }}/.aws/config
     owner={{ aws_cli_user }}
     group={{ aws_cli_user }}
     mode=0644

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,6 +22,18 @@
     owner={{ aws_cli_user }}
     group={{ aws_cli_user }}
     mode=0755
+  when: "not {{ aws_cli_user }} == \"root\""
+
+- name: 'Create the AWS config directory'
+  tags: 'aws-cli'
+  sudo: 'yes'
+  file: >
+    path=/root/.aws
+    state=directory
+    owner=root
+    group=root
+    mode=0755
+  when: "{{ aws_cli_user }} == \"root\""
 
 - name: 'Copy AWS CLI config'
   tags: 'aws-cli'


### PR DESCRIPTION
When running as the "root" user, the role creates the AWS configuration directory under /home/root/.aws which is not picked up when trying to run the CLI tools.

Added a task to set a "home directory" variable based on whether the user is "root" or not and updated the subsequent tasks to use this variable.
