### PR TITLE
Use become instead of deprecated sudo

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
 - name: 'Install Python PIP'
   tags: 'aws-cli'
-  sudo: 'yes'
+  become: 'yes'
   apt: >
     pkg=python-pip
     state=latest
 
 - name: 'Install AWS CLI'
   tags: 'aws-cli'
-  sudo: 'yes'
+  become: 'yes'
   pip: >
     name=awscli
     state=latest
@@ -25,7 +25,7 @@
 
 - name: 'Create the AWS config directory'
   tags: 'aws-cli'
-  sudo: 'yes'
+  become: 'yes'
   file: >
     path={{ home_dir }}/.aws
     state=directory
@@ -35,7 +35,7 @@
 
 - name: 'Copy AWS CLI config'
   tags: 'aws-cli'
-  sudo: 'yes'
+  become: 'yes'
   template: >
     src=aws_cli_config.j2
     dest={{ home_dir }}/.aws/config


### PR DESCRIPTION
Using sudo produces the warning:

[DEPRECATION WARNING]: Instead of sudo/sudo_user, use become/become_user and make sure become_method is 'sudo' (default).
This feature will be removed in a future release.