### PR TITLE
Add group variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 aws_cli_user: '{{ ansible_ssh_user }}'
+aws_cli_group: '{{ ansible_ssh_user }}'
 aws_output_format: 'json'
 aws_region: 'ap-southeast-2'
 aws_access_key_id: 'YOUR_ACCESS_KEY_ID'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,7 @@
     path={{ home_dir }}/.aws
     state=directory
     owner={{ aws_cli_user }}
-    group={{ aws_cli_user }}
+    group={{ aws_cli_group }}
     mode=0755
 
 - name: 'Copy AWS CLI config'
@@ -40,5 +40,5 @@
     src=aws_cli_config.j2
     dest={{ home_dir }}/.aws/config
     owner={{ aws_cli_user }}
-    group={{ aws_cli_user }}
+    group={{ aws_cli_group }}
     mode=0600


### PR DESCRIPTION
currently this project assumes that the user's group is the same as the user. on my setup (https://github.com/roots/trellis) defining `aws_cli_user` doesn't work since the group also has to be defined as something different