### PR TITLE
Add AWS credentials file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,3 +42,13 @@
     owner={{ aws_cli_user }}
     group={{ aws_cli_group }}
     mode=0600
+
+- name: 'Copy AWS CLI credentials'
+  tags: 'aws-cli'
+  become: 'yes'
+  template: >
+    src=aws_cli_credentials.j2
+    dest={{ home_dir }}/.aws/credentials
+    owner={{ aws_cli_user }}
+    group={{ aws_cli_group }}
+    mode=0600

--- a/templates/aws_cli_config.j2
+++ b/templates/aws_cli_config.j2
@@ -1,5 +1,3 @@
 [default]
 output = {{ aws_output_format }}
 region = {{ aws_region }}
-aws_access_key_id = {{ aws_access_key_id }}
-aws_secret_access_key = {{ aws_secret_access_key }}

--- a/templates/aws_cli_credentials.j2
+++ b/templates/aws_cli_credentials.j2
@@ -1,0 +1,3 @@
+[default]
+aws_access_key_id = {{ aws_access_key_id }}
+aws_secret_access_key = {{ aws_secret_access_key }}


### PR DESCRIPTION
Create the credentials file to store access and secret keys:
https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html

> The AWS credentials file – located at ~/.aws/credentials on Linux, macOS, or Unix, or at C:\Users\USERNAME \.aws\credentials on Windows. This file can contain multiple named profiles in addition to a default profile.