### PR TITLE
Change Galaxy role ref from ssilab to dstil

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The default variables are as follows:
 
     - hosts: 'servers'
       roles:
-        - role: 'ssilab.aws-cli'
+        - role: 'dstil.aws-cli'
           aws_output_format: 'json'
           aws_region: 'ap-southeast-2'
           aws_access_key_id: 'SUPER_SECRET_ACCESS_KEY_ID'   # Don't version this or put it on pastebin


### PR DESCRIPTION
The `README.md` file is currently referring to `ssilab.aws-cli` as the location of this role.  This PR updates it to `dstil.aws-cli`.