### PR TITLE
Fix deprecated Ansible Variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Installs and configures the AWS CLI for conveniently interacting with AWS servic
 
 ## Requirements
 
-Tested on Ubuntu 12.04 Server.
+-   Tested on Ubuntu 12.04 Server;
+-   Ansible 2.0+
 
 ## Role Variables
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-aws_cli_user: '{{ ansible_ssh_user }}'
-aws_cli_group: '{{ ansible_ssh_user }}'
+aws_cli_user: '{{ ansible_user }}'
+aws_cli_group: '{{ ansible_user }}'
 aws_output_format: 'json'
 aws_region: 'ap-southeast-2'
 aws_access_key_id: 'YOUR_ACCESS_KEY_ID'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: 'Installs and configures the AWS CLI for conveniently interacting with AWS services such as S3.'
   company: 'DSTIL'
   license: 'BSD'
-  min_ansible_version: 1.6
+  min_ansible_version: 2.0
   platforms:
   - name: 'Ubuntu'
     versions:


### PR DESCRIPTION
`ansible_ssh_user` was deprecated in Ansible 2 in favor of `ansible_user`.

It'd be good to update this one since it could cause some troubles for the many Ansible 2 users 🙂 